### PR TITLE
fix: update h11 to v0.16.0 to address critical security vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 annotated-types==0.7.0
 anyio==4.9.0
 certifi==2025.1.31
+charset-normalizer==3.3.2
 distro==1.9.0
-h11==0.14.0
-httpcore==1.0.8
+exceptiongroup==1.2.2
+h11==0.16.0
+httpcore==1.0.9
 httpx==0.28.1
 idna==3.10
 jiter==0.9.0
@@ -12,7 +14,9 @@ pydantic==2.11.3
 pydantic_core==2.33.1
 python-dotenv==1.1.0
 RapidFuzz==3.13.0
+requests==2.31.0
 sniffio==1.3.1
 tqdm==4.67.1
 typing-inspection==0.4.0
 typing_extensions==4.13.2
+urllib3==2.1.0


### PR DESCRIPTION
This PR addresses the critical security vulnerability CVE-2025-43859 in h11 library by upgrading from version 0.14.0 to 0.16.0.

<img width="557" alt="Screenshot 2025-04-25 at 10 05 34 AM" src="https://github.com/user-attachments/assets/cdb641ea-d7e5-4328-97f6-4ce100a330e7" />
